### PR TITLE
Implement status cmd

### DIFF
--- a/openvpn/client.go
+++ b/openvpn/client.go
@@ -229,7 +229,7 @@ func (c *MgmtClient) LatestStatus(statusFormat StatusFormat) ([][]byte, error) {
 	} else {
 		return nil, fmt.Errorf("Incorrect 'status' format option")
 	}
-	err := c.sendCommand([]byte("status"))
+	err := c.sendCommand(cmd)
 	if err != nil {
 		return nil, err
 	}

--- a/openvpn/client.go
+++ b/openvpn/client.go
@@ -208,6 +208,21 @@ func (c *MgmtClient) LatestState() (*StateEvent, error) {
 	}, nil
 }
 
+// LatestStatus .
+func (c *MgmtClient) LatestStatus() ([][]byte, error) {
+	err := c.sendCommand([]byte("status"))
+	if err != nil {
+		return nil, err
+	}
+
+	payload, err := c.readCommandResponsePayload()
+	if err != nil {
+		return nil, err
+	}
+
+	return payload, nil
+}
+
 // Pid retrieves the process id of the connected OpenVPN process.
 func (c *MgmtClient) Pid() (int, error) {
 	raw, err := c.simpleCommand("pid")

--- a/openvpn/client.go
+++ b/openvpn/client.go
@@ -16,6 +16,17 @@ var successPrefix = []byte("SUCCESS: ")
 var errorPrefix = []byte("ERROR: ")
 var endMessage = []byte("END")
 
+// StatusFormat enum type
+type StatusFormat string
+
+// StatusFormatDefault openvpn default status format
+// StatusFormatV3 openvpn version 3 status format
+const (
+	StatusFormatDefault StatusFormat = ""
+	StatusFormatV3      StatusFormat = "3"
+)
+
+// MgmtClient .
 type MgmtClient struct {
 	wr      io.Writer
 	replies <-chan []byte
@@ -208,8 +219,16 @@ func (c *MgmtClient) LatestState() (*StateEvent, error) {
 	}, nil
 }
 
-// LatestStatus .
-func (c *MgmtClient) LatestStatus() ([][]byte, error) {
+// LatestStatus retrieves the current daemon status information, in the same format as that produced by the OpenVPN --status directive.
+func (c *MgmtClient) LatestStatus(statusFormat StatusFormat) ([][]byte, error) {
+	var cmd []byte
+	if statusFormat == StatusFormatDefault {
+		cmd = []byte("status")
+	} else if statusFormat == StatusFormatV3 {
+		cmd = []byte("status 3")
+	} else {
+		return nil, fmt.Errorf("Incorrect 'status' format option")
+	}
 	err := c.sendCommand([]byte("status"))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Implement function for latest status of OpenVPN server

```
COMMAND -- status
-----------------

Show current daemon status information, in the same format as
that produced by the OpenVPN --status directive.

Command examples:

status   -- Show status information using the default status
            format version.

status 3 -- Show status information using the format of
            --status-version 3.
```